### PR TITLE
Add configurable target sheet

### DIFF
--- a/code.gs
+++ b/code.gs
@@ -17,6 +17,9 @@ const SECOND_FU_DELAY_MINUTES = 4  * 24 * 60;  // 4 days
 const THIRD_FU_DELAY_MINUTES  = 7  * 24 * 60;  // 7 days
 const FOURTH_FU_DELAY_MINUTES = 12 * 24 * 60;  // 12 days
 
+// Spreadsheet sheet that contains outreach contact data.
+const TARGET_SHEET_NAME = 'NameOfSheet';
+
 
 /**
  * Installable onEdit trigger: fires on ANY sheet when "Status" is edited.
@@ -24,7 +27,8 @@ const FOURTH_FU_DELAY_MINUTES = 12 * 24 * 60;  // 12 days
  */
 function onEditTrigger(e) {
   if (!e || !e.range) return;
-  const sh   = e.range.getSheet();
+  const sh = e.source.getSheetByName(TARGET_SHEET_NAME);
+  if (!sh || e.range.getSheet().getName() !== TARGET_SHEET_NAME) return;
   const hdrs = sh.getRange(1, 1, 1, sh.getLastColumn()).getValues()[0];
 
   // 1) Find Status column
@@ -289,7 +293,8 @@ function isLastMessageFromContact_(thread, email) {
  * Intended to run daily via a time-based Apps Script trigger.
  */
 function autoSendFollowUps() {
-  const sh   = SpreadsheetApp.getActiveSheet();
+  const sh = SpreadsheetApp.getActiveSpreadsheet().getSheetByName(TARGET_SHEET_NAME);
+  if (!sh) return;
   const hdrs = sh.getRange(1, 1, 1, sh.getLastColumn()).getValues()[0];
 
   const nameCol      = hdrs.indexOf('First/Last Name') + 1;


### PR DESCRIPTION
## Summary
- add `TARGET_SHEET_NAME` constant
- use target sheet in `onEditTrigger`
- use target sheet in `autoSendFollowUps`

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_683cd494100083288a5438cf3a9eadb3