### PR TITLE
Improve thread search for follow ups

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ The `FROM_ALIAS` constant controls which Gmail alias the script uses to send mes
 4. Add a row for each contact and update the **Status** cell with tags such as `Outreach`, `1st Follow Up`, etc. Editing the status will send the matching email template.
 5. Customize the template text and delay constants in `code.gs` as needed.
 6. When a contact replies, `autoSendFollowUps` writes `New Response` to the **Reply Status** column and highlights the cell using `NEW_RESPONSE_COLOR` (red by default). If your message is the most recent, the cell is cleared and its background reset.
+7. The follow-up routine searches Gmail using `in:anywhere (to:EMAIL OR from:EMAIL) subject:"SUBJECT"` so threads are matched whether messages were sent to the contact or received from them.
 
 With the Gmail service enabled and triggers installed, the script manages your outreach and follow‑ups directly from Gmail while updating status information in your spreadsheet.
 

--- a/code.gs
+++ b/code.gs
@@ -340,7 +340,7 @@ function buildRawMessage_(to, subject, textBody, htmlBody, inReplyTo) {
 
 /**
 
- * Helper: checks if the last message in a thread came from the contact.
+ * Helper: checks if the most recent message in a thread came from the contact.
  *
  * @param {GmailThread} thread The Gmail thread to inspect.
  * @param {string} email       The contact's email address.
@@ -387,7 +387,9 @@ function autoSendFollowUps() {
     const tags   = status.split(',').map(t => t.trim()).filter(Boolean);
     if (tags.includes('Moved to DM')) return;
 
-    const query   = `in:anywhere to:${email} subject:"${OUTREACH_SUBJECT}"`;
+    // Search threads that include messages sent to or received from the contact
+    const query   =
+      `in:anywhere (to:${email} OR from:${email}) subject:"${OUTREACH_SUBJECT}"`;
     const threads = GmailApp.search(query);
     if (!threads.length) return;
 


### PR DESCRIPTION
## Summary
- search Gmail threads for messages *from* or *to* the contact
- note the new search query in the README
- clarify that `isLastMessageFromContact_` checks the most recent message

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_683dd6b81ba88328b1f546863c52fd94