### PR TITLE
Link reply status to Gmail thread

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ The `FROM_ADDRESS` constant controls which Gmail address the script uses to send
 3. Install a daily time‑driven trigger for `autoSendFollowUps` so unanswered threads continue to receive follow‑ups automatically.
 4. Add a row for each contact and update the **Status** cell with tags such as `Outreach`, `1st Follow Up`, etc. Editing the status will send the matching email template.
 5. Customize the template text and delay constants in `code.gs` as needed.
-6. When a contact replies, `autoSendFollowUps` writes `New Response` to the **Reply Status** column and highlights the cell using `NEW_RESPONSE_COLOR` (red by default). If your message is the most recent, the cell is cleared and its background reset.
+6. When a contact replies, `autoSendFollowUps` writes `New Response` to the **Reply Status** column, highlights the cell using `NEW_RESPONSE_COLOR`, and links the text directly to the Gmail thread. After the final follow‑up the script marks `Moved to DM` with the same linked thread. If your message is the most recent, the cell is cleared and its background reset.
 7. The follow-up routine searches Gmail using `in:anywhere (to:EMAIL OR from:EMAIL) subject:"SUBJECT"` so threads are matched whether messages were sent to the contact or received from them.
 
 With the Gmail service enabled and triggers installed, the script manages your outreach and follow‑ups directly from Gmail while updating status information in your spreadsheet.


### PR DESCRIPTION
## Summary
- add GMAIL_THREAD_LINK_PREFIX constant
- add `setReplyStatusWithLink_` helper
- link "New Response" and "Moved to DM" statuses to their Gmail threads
- document linked reply status behavior in README

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_683de7184edc83288b7fb3625fd25324