### PR TITLE
Merge duplicate outreach starter

### DIFF
--- a/code.gs
+++ b/code.gs
@@ -135,7 +135,11 @@ function startOutreachForSelectedRow() {
     return;
   }
 
-  const row = sh.getActiveCell().getRow();
+  const range = sh.getActiveRange();
+  if (!range) return;
+  const row = range.getRow();
+  if (row <= 1) return;
+
   const hdrs = sh.getRange(1, 1, 1, sh.getLastColumn()).getValues()[0];
   const nameCol   = hdrs.indexOf('First/Last Name') + 1;
   const emailCol  = hdrs.indexOf('Email') + 1;
@@ -484,29 +488,3 @@ function autoSendFollowUps() {
   });
 }
 
-/**
- * Send the outreach email for the currently selected row.
- * Attach this function to a button for one-click outreach.
- */
-function startOutreachForSelectedRow() {
-  const ss = SpreadsheetApp.getActiveSpreadsheet();
-  const sh = ss.getSheetByName(TARGET_SHEET_NAME);
-  if (!sh) return;
-  const range = sh.getActiveRange();
-  if (!range) return;
-  const row = range.getRow();
-  if (row <= 1) return;
-
-  const headers = sh.getRange(1, 1, 1, sh.getLastColumn()).getValues()[0];
-  const nameCol  = headers.indexOf('First/Last Name') + 1;
-  const emailCol = headers.indexOf('Email') + 1;
-  if (nameCol < 1 || emailCol < 1) return;
-
-  const values = sh.getRange(row, 1, 1, sh.getLastColumn()).getValues()[0];
-  const full  = values[nameCol - 1] || '';
-  const first = full.split(/\s+/)[0];
-  const email = values[emailCol - 1];
-  if (!email) return;
-
-  sendInitialForRow(email, first);
-}


### PR DESCRIPTION
## Summary
- merge the duplicate `startOutreachForSelectedRow` implementations
- keep sheet validation and status tagging logic
- remove leftover duplicate comment

## Testing
- `npm test` *(fails: Could not read package.json)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_683deaa3b908832895f726e6c6dad5cf