### PR TITLE
Fix README Configuration text

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,9 +18,6 @@ The script sends an initial outreach email and up to four follow‑up messages. 
 
 ### Configuration
 
-
-The `FROM_ADDRESS` constant controls which Gmail address the script uses to send messages. Set it to the single account that will manage your outreach.
-
 The `FROM_ADDRESS` constant controls which Gmail address the script uses to send messages. Set it to the single account that will manage your outreach. The script checks incoming replies on this same address to stop follow‑ups automatically.
 
 `NEW_RESPONSE_COLOR` sets the background color applied to the **Reply Status** cell when a contact replies. The default is `red` but you can change it to any valid Sheets color name or hex value.


### PR DESCRIPTION
## Summary
- remove duplicate sentences for `FROM_ADDRESS` in Configuration section

## Testing
- `grep -n FROM_ADDRESS README.md`


------
https://chatgpt.com/codex/tasks/task_e_683deaa461648328931d3de69677e221