### PR TITLE
Remove duplicate outreach log

### DIFF
--- a/code.gs
+++ b/code.gs
@@ -116,8 +116,6 @@ function sendInitialForRow(email, firstName) {
   Gmail.Users.Messages.send({ raw: raw }, 'me');
 
   Logger.log('Outreach sent via Advanced API to %s with subject "%s"', email, subject);
-
-  Logger.log('Outreach sent via API to %s with subject "%s"', email, subject);
 }
 
 /**


### PR DESCRIPTION
## Summary
- avoid duplicate logging for outreach API send

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_683f5ec11664832881b07803d22346fc