### PR TITLE
Improve follow-up status tracking

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ The `FROM_ADDRESS` constant controls which Gmail address the script uses to send
 3. Install a daily time‑driven trigger for `autoSendFollowUps` so unanswered threads continue to receive follow‑ups automatically.
 4. Add a row for each contact and update the **Status** cell with tags such as `Outreach`, `1st Follow Up`, etc. Editing the status will send the matching email template.
 5. Customize the template text and delay constants in `code.gs` as needed.
-6. When a contact replies, `autoSendFollowUps` writes `New Response` to the **Reply Status** column, highlights the cell using `NEW_RESPONSE_COLOR`, and links the text directly to the Gmail thread. After the final follow‑up the script marks `Moved to DM` with the same linked thread. If your message is the most recent, the cell is cleared and its background reset.
+6. Each run examines the most recent message in every thread. If the contact wrote last the **Reply Status** cell shows `New Response` in red. Once you respond it changes to `Replied`; otherwise it reads `Waiting`. The status text always links back to the Gmail thread and is refreshed even if you clear the cell. After the final follow‑up the script marks `Moved to DM`.
 7. The follow-up routine searches Gmail using `in:anywhere (to:EMAIL OR from:EMAIL) subject:"SUBJECT"` so threads are matched whether messages were sent to the contact or received from them.
 
 With the Gmail service enabled and triggers installed, the script manages your outreach and follow‑ups directly from Gmail while updating status information in your spreadsheet.


### PR DESCRIPTION
## Summary
- add helpers to extract email addresses and to determine thread status
- update `autoSendFollowUps` to record `Waiting`, `New Response`, or `Replied` for every run
- store `Replied` tag to avoid further follow ups
- refresh reply status hyperlink and color on each execution
- document new behavior in README

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68406e38cc488328b03558593687f340