### PR TITLE
Handle alias replies when stopping follow‑ups

### DIFF
--- a/code.gs
+++ b/code.gs
@@ -11,7 +11,7 @@ const TARGET_SHEET_NAME = 'Influencer PR';
 // aliases and makes reply detection reliable.
 const FROM_ADDRESS = 'creators@clubkalm.com';
 
-// Background color used when marking a new reply in the sheet.
+// Background color used when marking any reply in the sheet.
 const NEW_RESPONSE_COLOR = 'red';
 
 // Background color used when a contact is moved to DM.
@@ -356,6 +356,20 @@ function extractEmail_(from) {
 }
 
 /**
+ * Helper: checks if the address belongs to the script owner or any alias.
+ *
+ * @param {string} addr Email address to test.
+ * @return {boolean} True if the address is one of ours.
+ */
+function isMyAddress_(addr) {
+  addr = addr.toLowerCase();
+  const mine = GmailApp.getAliases()
+    .map(a => a.toLowerCase())
+    .concat(Session.getActiveUser().getEmail().toLowerCase(), FROM_ADDRESS.toLowerCase());
+  return mine.some(a => a === addr);
+}
+
+/**
  * Determines the reply status for a thread.
  *
  * @param {GmailThread} thread Gmail thread to examine.
@@ -366,18 +380,17 @@ function getLatestThreadStatus_(thread, email) {
   const messages = thread.getMessages();
   if (!messages.length) return 'Waiting';
 
-  const myAddr      = FROM_ADDRESS.toLowerCase();
   const contactAddr = email.toLowerCase();
 
-  const lastMsg   = messages[messages.length - 1];
-  const lastAddr  = extractEmail_(lastMsg.getFrom());
+  const lastMsg  = messages[messages.length - 1];
+  const lastAddr = extractEmail_(lastMsg.getFrom());
 
   if (lastAddr === contactAddr) {
     return 'New Response';
   }
 
   const contactEver = messages.some(m => extractEmail_(m.getFrom()) === contactAddr);
-  if (lastAddr === myAddr && contactEver) {
+  if (isMyAddress_(lastAddr) && contactEver) {
     return 'Replied';
   }
 
@@ -449,7 +462,9 @@ function autoSendFollowUps() {
     const replyCell = sh.getRange(row, replyCol);
     const threadStatus = getLatestThreadStatus_(thread, email);
     const statusColor =
-      threadStatus === 'New Response' ? NEW_RESPONSE_COLOR : null;
+      threadStatus === 'New Response' || threadStatus === 'Replied'
+        ? NEW_RESPONSE_COLOR
+        : null;
     setReplyStatusWithLink_(replyCell, threadStatus, thread.getId(), statusColor);
 
     if (threadStatus === 'New Response' || threadStatus === 'Replied') {


### PR DESCRIPTION
## Summary
- detect if a message is from any of the account's aliases
- use alias detection in reply status checks to stop follow-ups once a response occurs
- color the reply cell red for both `New Response` and `Replied`

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68420cf87c7083288ff979bc76542346