### PR TITLE
Fix getMyAddresses_ and cleanup stray lines

### DIFF
--- a/code.gs
+++ b/code.gs
@@ -363,8 +363,11 @@ function extractEmail_(from) {
 function getMyAddresses_() {
   const aliases = GmailApp.getAliases();
   return [FROM_ADDRESS.toLowerCase()].concat(
-    aliases.map(a => a.toLowerCase()),
+    aliases.map(a => a.toLowerCase())
   );
+}
+
+/**
  * Helper: checks if the address belongs to the script owner or any alias.
  *
  * @param {string} addr Email address to test.


### PR DESCRIPTION
## Summary
- ensure `getMyAddresses_` ends with a closing brace
- restore comment block before `isMyAddress_`
- remove stray `* Helper:` lines

## Testing
- `node - <<'EOF'
const fs=require('fs');
const code=fs.readFileSync('code.gs','utf8');
try{new Function(code);console.log('OK');}catch(e){console.log('ERROR',e.message);}
EOF`

------
https://chatgpt.com/codex/tasks/task_e_6846cc0699688328a420b509ec8349b3