### PR TITLE
Refactor latest thread status logic

### DIFF
--- a/code.gs
+++ b/code.gs
@@ -428,20 +428,21 @@ function getLatestThreadStatus_(thread, email) {
   if (!messages.length) return 'Waiting';
 
   const contactAddr = email.toLowerCase();
-  const lastMsg = messages[messages.length - 1];
-  const lastAddr = extractEmail_(lastMsg.getFrom()).toLowerCase();
+  const lastAddr = extractEmail_(
+    messages[messages.length - 1].getFrom()
+  ).toLowerCase();
+  const contactEver = messages.some(
+    m => extractEmail_(m.getFrom()).toLowerCase() === contactAddr
+  );
 
   if (lastAddr === contactAddr) {
     return 'New Response';
   }
 
-  const contactEver = messages.some(
-    m => extractEmail_(m.getFrom()).toLowerCase() === contactAddr
-  );
-
   if (isMyAddress_(lastAddr) && contactEver) {
     return 'Replied';
   }
+
   return contactEver ? 'Replied' : 'Waiting';
 }
 


### PR DESCRIPTION
## Summary
- simplify detection of latest thread status

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68473ff5e43c8328adcfa8e25c37a750