### PR TITLE
Implement quota check for auto-send follow-ups

### DIFF
--- a/code.gs
+++ b/code.gs
@@ -467,6 +467,11 @@ function setReplyStatusWithLink_(cell, text, threadId, color) {
  */
 function autoSendFollowUps() {
   if (!isAutoSendEnabled()) return;
+  const remaining = MailApp.getRemainingDailyQuota();
+  if (remaining < 10) {
+    Logger.log('Daily quota low (%s emails remaining); skipping follow-ups.', remaining);
+    return;
+  }
   const ss   = SpreadsheetApp.getActiveSpreadsheet();
   const sh   = ss.getSheetByName(TARGET_SHEET_NAME);
   if (!sh) return;


### PR DESCRIPTION
## Summary
- prevent follow-up run when Gmail daily quota is almost used up

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6847401ead68832882cc43a86c96de19