### PR TITLE
Ensure follow‑ups require Outreach tag

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ auto-sending anytime from **Project Settings → Script properties** by setting
 2. Install an **On edit** trigger for the `onEditTrigger` function.
 3. Install a daily time‑driven trigger for `autoSendFollowUps` so unanswered threads continue to receive follow‑ups automatically.
 4. Add a row for each contact and update the **Status** cell with tags such as `Outreach`, `1st Follow Up`, etc. Editing the status will send the matching email template.
+   Follow-up messages are only sent when the row still includes the `Outreach` tag; clearing it stops further emails.
 5. Customize the template text and delay constants in `code.gs` as needed.
 6. Each run examines the most recent message in every thread. If the contact wrote last the **Reply Status** cell shows `New Response` in red. Once you respond it changes to `Replied`; otherwise it reads `Waiting`. The status text always links back to the Gmail thread and is refreshed even if you clear the cell. After the final follow‑up the script marks `Moved to DM`.
 7. The follow-up routine uses the stored **Thread ID** to open each conversation. If that column is blank it falls back to the search query `in:anywhere (to:EMAIL OR from:EMAIL) subject:"SUBJECT"`.

--- a/code.gs
+++ b/code.gs
@@ -76,6 +76,10 @@ function onEditTrigger(e) {
   // 3) Compute which tags were just added
   const newTags = newStatus.split(',').map(t => t.trim()).filter(Boolean);
   const oldTags = oldStatus.split(',').map(t => t.trim()).filter(Boolean);
+  if (!newTags.includes('Outreach')) {
+    Logger.log('Row no longer tagged Outreach; skipping trigger.');
+    return;
+  }
   const additions = newTags.filter(t => !oldTags.includes(t));
   if (!additions.length) return;
   Logger.log('Tags added: %s', additions.join(', '));
@@ -561,6 +565,7 @@ function autoSendFollowUps() {
     let status   = vals[statusCol - 1] || '';
     const storedThreadId = vals[threadIdCol - 1];
     const tags   = status.split(',').map(t => t.trim()).filter(Boolean);
+    if (!tags.includes('Outreach')) return;
     if (tags.includes('Moved to DM')) return;
 
     let thread = null;


### PR DESCRIPTION
## Summary
- skip on-edit actions when the updated row no longer contains the `Outreach` tag
- require the `Outreach` tag in `autoSendFollowUps`
- document that clearing `Outreach` stops scheduled emails

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6847600f69f48328a98f079dc2c1c3ba