### PR TITLE
Add macro to toggle follow ups

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,9 @@ Any "Send mail as" aliases configured in Gmail are detected automatically, so re
 `AutoSendEnabled` is a script property that controls whether follow-ups are sent
 automatically. Clicking the outreach button sets it to `TRUE`. You can disable
 auto-sending anytime from **Project Settings → Script properties** by setting
-`AutoSendEnabled` to `FALSE`.
+`AutoSendEnabled` to `FALSE`. To flip this value without opening settings, run
+the `toggleAutoSendEnabled` function from **Extensions → Macros** or assign it
+to a sheet button.
 
 ## Basic Usage
 
@@ -52,3 +54,10 @@ the currently highlighted row:
 
 Now clicking the button will send the initial outreach email for the active row
 and tag its **Status** cell with `Outreach`.
+
+### Optional: Toggle Auto-Send
+
+Import `toggleAutoSendEnabled` under **Extensions → Macros → Import** to make it
+available from the Macros menu. You can also assign this function to another
+sheet button. Each time it runs, the `AutoSendEnabled` property switches between
+`TRUE` and `FALSE` and a dialog confirms the new state.

--- a/code.gs
+++ b/code.gs
@@ -55,6 +55,18 @@ function isAutoSendEnabled() {
 }
 
 /**
+ * Toggle automatic sending of follow-ups on or off.
+ * Can be run from Extensions → Macros or a sheet button.
+ */
+function toggleAutoSendEnabled() {
+  const enabled = !isAutoSendEnabled();
+  setAutoSendEnabled(enabled);
+  SpreadsheetApp.getUi().alert(
+    `Automatic follow-ups ${enabled ? 'enabled' : 'disabled'}.`,
+  );
+}
+
+/**
  * Installable onEdit trigger: fires on ANY sheet when "Status" is edited.
  * Now only dispatches on the tag(s) you just added.
  */


### PR DESCRIPTION
## Summary
- allow toggling automatic follow-ups via `toggleAutoSendEnabled`
- document how to use the new macro in the README

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6847602b718c8328a7362ea4c2172f18