### PR TITLE
Remove quota check from auto-sending follow-ups

### DIFF
--- a/code.gs
+++ b/code.gs
@@ -557,11 +557,6 @@ function setReplyStatusWithLink_(cell, text, threadId, color) {
  */
 function autoSendFollowUps() {
   if (!isAutoSendEnabled()) return;
-  const remaining = MailApp.getRemainingDailyQuota();
-  if (remaining < 10) {
-    Logger.log('Daily quota low (%s emails remaining); skipping follow-ups.', remaining);
-    return;
-  }
   const ss   = SpreadsheetApp.getActiveSpreadsheet();
   const sh   = ss.getSheetByName(TARGET_SHEET_NAME);
   if (!sh) return;


### PR DESCRIPTION
## Summary
- remove the `MailApp.getRemainingDailyQuota()` check from `autoSendFollowUps`
- allow automatic follow-ups whenever auto-send is enabled

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68476bd94ba4832881b38d94f2b14c7d