### PR TITLE
Fix duplicate row reads in onEditTrigger

### DIFF
--- a/code.gs
+++ b/code.gs
@@ -114,11 +114,6 @@ function onEditTrigger(e) {
   const last   = (vals[lastNameCol - 1]  || '').toString();
   const email  = vals[emailCol - 1];
   const threadId = vals[threadIdCol - 1];
-  const vals     = sh.getRange(row, 1, 1, sh.getLastColumn()).getValues()[0];
-  const first    = (vals[firstNameCol - 1] || '').toString();
-  const last     = (vals[lastNameCol - 1]  || '').toString();
-  const email    = vals[emailCol - 1];
-  const threadId = threadCol > 0 ? vals[threadCol - 1] : null;
   if (!email) return;
   if (!first && !last) return;
 


### PR DESCRIPTION
## Summary
- remove duplicate row-read logic from `onEditTrigger`

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68484abc3a4c83288c65bec851b1c292