### PR TITLE
Clarify how AutoSend toggle interacts with trigger

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,10 @@ auto-sending anytime from **Project Settings → Script properties** by setting
 the `toggleAutoSendEnabled` function from **Extensions → Macros** or assign it
 to a sheet button.
 
+Toggling this value only stops follow-ups logically. The time-driven trigger
+continues to invoke `autoSendFollowUps`, which consumes an execution each day.
+Delete the trigger entirely if you need to pause scheduled runs.
+
 ## Basic Usage
 
 1. In your spreadsheet create columns titled **First Name**, **Last Name**, **Email**, **Status**, **Stage**, **Reply Status**, and **Thread ID**.
@@ -60,3 +64,5 @@ Import `toggleAutoSendEnabled` under **Extensions → Macros → Import** to mak
 available from the Macros menu. You can also assign this function to another
 sheet button. Each time it runs, the `AutoSendEnabled` property switches between
 `TRUE` and `FALSE` and a dialog confirms the new state.
+This does not stop the time-driven trigger from running; delete that trigger if
+you want to halt follow-up checks completely.


### PR DESCRIPTION
## Summary
- explain how `AutoSendEnabled` interacts with the time-driven trigger
- describe how to fully stop automatic follow-ups

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68485648fdc8832889425ef272e2f09c