### PR TITLE
Add auto send disabled log

### DIFF
--- a/code.gs
+++ b/code.gs
@@ -549,7 +549,10 @@ function setReplyStatusWithLink_(cell, text, threadId, color) {
  * Intended to run daily via a time-based Apps Script trigger.
  */
 function autoSendFollowUps() {
-  if (!isAutoSendEnabled()) return;
+  if (!isAutoSendEnabled()) {
+    Logger.log('Auto-send disabled; skipping run.');
+    return;
+  }
   const ss   = SpreadsheetApp.getActiveSpreadsheet();
   const sh   = ss.getSheetByName(TARGET_SHEET_NAME);
   if (!sh) return;


### PR DESCRIPTION
## Summary
- log when auto-send is disabled in `autoSendFollowUps`

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68485647c894832895c5cb8b5b21ffad