### PR TITLE
Cache alias list for faster reply status checks

### DIFF
--- a/code.gs
+++ b/code.gs
@@ -489,11 +489,11 @@ function getMyAddresses_() {
  * @param {string} addr Email address to test.
  * @return {boolean} True if the address is one of ours.
  */
-function isMyAddress_(addr) {
+function isMyAddress_(addr, myAddrs) {
   addr = addr.toLowerCase();
-  const mine = GmailApp.getAliases()
-    .map(a => a.toLowerCase())
-    .concat(Session.getActiveUser().getEmail().toLowerCase(), FROM_ADDRESS.toLowerCase());
+  const list = myAddrs || getMyAddresses_();
+  // Include the primary account address in case it's not part of aliases
+  const mine = list.concat(Session.getActiveUser().getEmail().toLowerCase());
   return mine.some(a => a === addr);
 }
 
@@ -504,7 +504,7 @@ function isMyAddress_(addr) {
  * @param {string} email       Contact email address.
  * @return {string} Status: "New Response", "Replied", or "Waiting".
  */
-function getLatestThreadStatus_(thread, email) {
+function getLatestThreadStatus_(thread, email, myAddrs) {
   const messages = thread.getMessages();
   if (!messages.length) return 'Waiting';
 
@@ -520,7 +520,7 @@ function getLatestThreadStatus_(thread, email) {
     return 'New Response';
   }
 
-  if (isMyAddress_(lastAddr) && contactEver) {
+  if (isMyAddress_(lastAddr, myAddrs) && contactEver) {
     return 'Replied';
   }
 
@@ -550,6 +550,7 @@ function setReplyStatusWithLink_(cell, text, threadId, color) {
  */
 function autoSendFollowUps() {
   if (!isAutoSendEnabled()) return;
+  const myAddrs = getMyAddresses_();
   const ss   = SpreadsheetApp.getActiveSpreadsheet();
   const sh   = ss.getSheetByName(TARGET_SHEET_NAME);
   if (!sh) return;
@@ -604,7 +605,7 @@ function autoSendFollowUps() {
       return;
     }
     const replyCell = sh.getRange(row, replyCol);
-    const threadStatus = getLatestThreadStatus_(thread, email);
+    const threadStatus = getLatestThreadStatus_(thread, email, myAddrs);
     const statusColor =
       threadStatus === 'New Response' || threadStatus === 'Replied'
         ? NEW_RESPONSE_COLOR


### PR DESCRIPTION
## Summary
- avoid repeated `GmailApp.getAliases()` calls
- cache aliases with `getMyAddresses_()` and pass list to `isMyAddress_`
- use cached list in `autoSendFollowUps`

## Testing
- `node --check code.gs` *(fails: Unknown file extension)*
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_6848564707a48328a47230c04c80e0e6