### PR TITLE
Fix onEdit Outreach auto-send

### DIFF
--- a/code.gs
+++ b/code.gs
@@ -123,6 +123,7 @@ function onEditTrigger(e) {
       case 'Outreach':
         Logger.log('Dispatching Outreach for %s', email);
         sendInitialForRow(email, first, row);
+        setAutoSendEnabled(true);
         if (stageCol > 0) {
           sh.getRange(row, stageCol).setValue('Outreach');
         }


### PR DESCRIPTION
## Summary
- activate automatic follow-ups when outreach is sent from onEdit

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68485645a9f48328b4a0083c582cd501