### PR TITLE
Enable automatic follow-ups

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,11 +24,12 @@ Any "Send mail as" aliases configured in Gmail are detected automatically, so re
 `NEW_RESPONSE_COLOR` sets the background color applied to the **Reply Status** cell when a contact replies. The default is `red` but you can change it to any valid Sheets color name or hex value.
 
 `AutoSendEnabled` is a script property that controls whether follow-ups are sent
-automatically. Clicking the outreach button sets it to `TRUE`. You can disable
-auto-sending anytime from **Project Settings → Script properties** by setting
-`AutoSendEnabled` to `FALSE`. To flip this value without opening settings, run
-the `toggleAutoSendEnabled` function from **Extensions → Macros** or assign it
-to a sheet button.
+automatically. The property is set to `TRUE` the first time an outreach email is
+sent so follow-ups start immediately. You can disable auto-sending anytime from
+**Project Settings → Script properties** by setting `AutoSendEnabled` to
+`FALSE`. To flip this value without opening settings, run the
+`toggleAutoSendEnabled` function from **Extensions → Macros** or assign it to a
+sheet button.
 
 ## Basic Usage
 
@@ -38,6 +39,7 @@ to a sheet button.
 3. Install a daily time‑driven trigger for `autoSendFollowUps` so unanswered threads continue to receive follow‑ups automatically.
 4. Add a row for each contact and update the **Status** cell with tags such as `Outreach`, `1st Follow Up`, etc. Editing the status will send the matching email template.
    Follow-up messages are only sent when the row still includes the `Outreach` tag; clearing it stops further emails.
+   The first outreach email automatically enables auto-sending so subsequent follow-ups are queued without extra steps.
 5. Customize the template text and delay constants in `code.gs` as needed.
 6. Each run examines the most recent message in every thread. If the contact wrote last the **Reply Status** cell shows `New Response` in red. Once you respond it changes to `Replied`; otherwise it reads `Waiting`. The status text always links back to the Gmail thread and is refreshed even if you clear the cell. After the final follow‑up the script marks `Moved to DM`.
 7. The follow-up routine uses the stored **Thread ID** to open each conversation. If the thread cannot be retrieved by ID that contact is skipped.

--- a/code.gs
+++ b/code.gs
@@ -188,6 +188,9 @@ function sendInitialForRow(email, firstName, rowIndex) {
     }
   }
 
+  // Enable automatic follow-up sending once the first outreach goes out.
+  setAutoSendEnabled(true);
+
   Logger.log('Outreach sent via Advanced API to %s with subject "%s"', email, subject);
 }
 
@@ -239,9 +242,6 @@ function startOutreachForSelectedRow() {
   }
 
   sendInitialForRow(email, first, row);
-
-  // Enable automatic follow-up sending after the first outreach.
-  setAutoSendEnabled(true);
 
   if (stageCol > 0) {
     sh.getRange(row, stageCol).setValue('Outreach');


### PR DESCRIPTION
## Summary
- enable auto-send property when sending the first outreach email
- remove redundant call in `startOutreachForSelectedRow`
- document automatic follow-ups in README

## Testing
- `npm test` *(fails: no package.json)*

------
https://chatgpt.com/codex/tasks/task_e_684852da9138832890a5af677a11e4d4