### PR TITLE
Simplify follow up logic

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,8 +21,6 @@ The script sends an initial outreach email and up to four follow‑up messages. 
 The `FROM_ADDRESS` constant controls which Gmail address the script uses to send messages. Set it to the single account that will manage your outreach. The script checks incoming replies on this same address to stop follow‑ups automatically.
 Any "Send mail as" aliases configured in Gmail are detected automatically, so replies to those addresses are also recognized.
 
-`NEW_RESPONSE_COLOR` sets the background color applied to the **Reply Status** cell when a contact replies. The default is `red` but you can change it to any valid Sheets color name or hex value.
-
 `AutoSendEnabled` is a script property that controls whether follow-ups are sent
 automatically. The property is set to `TRUE` the first time an outreach email is
 sent so follow-ups start immediately. You can disable auto-sending anytime from
@@ -37,16 +35,13 @@ Delete the trigger entirely if you need to pause scheduled runs.
 
 ## Basic Usage
 
-1. In your spreadsheet create columns titled **First Name**, **Last Name**, **Email**, **Status**, **Stage**, **Reply Status**, and **Thread ID**.
-   The thread ID column will be populated automatically after the first outreach and is required for all follow‑ups.
+1. In your spreadsheet create columns titled **First Name**, **Last Name**, **Email**, **Status**, and **Stage**.
 2. Install an **On edit** trigger for the `onEditTrigger` function.
 3. Install a daily time‑driven trigger for `autoSendFollowUps` so unanswered threads continue to receive follow‑ups automatically.
 4. Add a row for each contact and update the **Status** cell with tags such as `Outreach`, `1st Follow Up`, etc. Editing the status will send the matching email template.
    Follow-up messages are only sent when the row still includes the `Outreach` tag; clearing it stops further emails.
    The first outreach email automatically enables auto-sending so subsequent follow-ups are queued without extra steps.
 5. Customize the template text and delay constants in `code.gs` as needed.
-6. Each run examines the most recent message in every thread. If the contact wrote last the **Reply Status** cell shows `New Response` in red. Once you respond it changes to `Replied`; otherwise it reads `Waiting`. The status text always links back to the Gmail thread and is refreshed even if you clear the cell. After the final follow‑up the script marks `Moved to DM`.
-7. The follow-up routine uses the stored **Thread ID** to open each conversation. If the thread cannot be retrieved by ID that contact is skipped.
 
 With the Gmail service enabled and triggers installed, the script manages your outreach and follow‑ups directly from Gmail while updating status information in your spreadsheet.
 


### PR DESCRIPTION
## Summary
- drop Thread ID and Reply Status handling
- search Gmail for threads on follow-ups
- remove reply status utilities
- document new header requirements

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6848a6f62dec8328a854e186079db26d