### PR TITLE
Refactor follow‑ups to rely on message IDs

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,16 +37,15 @@ Delete the trigger entirely if you need to pause scheduled runs.
 
 ## Basic Usage
 
-1. In your spreadsheet create columns titled **First Name**, **Last Name**, **Email**, **Status**, **Stage**, **Reply Status**, and **Thread ID**.
-   The thread ID column will be populated automatically after the first outreach and is required for all follow‑ups.
+1. In your spreadsheet create columns titled **First Name**, **Last Name**, **Email**, **Status**, **Stage**, **Reply Status**, and **Message IDs**.
+   The message ID column is populated automatically after each send and prevents duplicate follow‑ups.
 2. Install an **On edit** trigger for the `onEditTrigger` function.
-3. Install a daily time‑driven trigger for `autoSendFollowUps` so unanswered threads continue to receive follow‑ups automatically.
+3. Install a daily time‑driven trigger for `autoSendFollowUps` so unanswered contacts continue to receive follow‑ups automatically.
 4. Add a row for each contact and update the **Status** cell with tags such as `Outreach`, `1st Follow Up`, etc. Editing the status will send the matching email template.
    Follow-up messages are only sent when the row still includes the `Outreach` tag; clearing it stops further emails.
    The first outreach email automatically enables auto-sending so subsequent follow-ups are queued without extra steps.
 5. Customize the template text and delay constants in `code.gs` as needed.
-6. Each run examines the most recent message in every thread. If the contact wrote last the **Reply Status** cell shows `New Response` in red. Once you respond it changes to `Replied`; otherwise it reads `Waiting`. The status text always links back to the Gmail thread and is refreshed even if you clear the cell. After the final follow‑up the script marks `Moved to DM`.
-7. The follow-up routine uses the stored **Thread ID** to open each conversation. If the thread cannot be retrieved by ID that contact is skipped.
+6. Each run checks Gmail for replies from the contact. When a response arrives the **Reply Status** cell changes to `Replied` and the `Outreach` tag is cleared. After the final follow‑up the script marks `Moved to DM`.
 
 With the Gmail service enabled and triggers installed, the script manages your outreach and follow‑ups directly from Gmail while updating status information in your spreadsheet.
 


### PR DESCRIPTION
## Summary
- remove thread ID usage and track message IDs instead
- add helper functions for finding sent messages and replies
- rewrite follow-up sending logic and status updates
- document new **Message IDs** column in README

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6848a6fba52c83289068b536569b0780