### PR TITLE
Fix duplicate auto-send check

### DIFF
--- a/code.gs
+++ b/code.gs
@@ -577,8 +577,6 @@ function autoSendFollowUps() {
     Logger.log('Auto-send disabled; skipping run.');
     return;
   }
-
-  if (!isAutoSendEnabled()) return;
   const myAddrs = getMyAddresses_();
   const ss   = SpreadsheetApp.getActiveSpreadsheet();
   const sh   = ss.getSheetByName(TARGET_SHEET_NAME);


### PR DESCRIPTION
## Summary
- remove redundant check for `isAutoSendEnabled` in `autoSendFollowUps`

## Testing
- `npm test` *(fails: no package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6848a70fc684832895559e6be823c8ca