### PR TITLE
Fix outreach start to read headers and update sheet

### DIFF
--- a/code.gs
+++ b/code.gs
@@ -196,6 +196,32 @@ function startOutreachForSelectedRow() {
   const range = sh.getActiveRange();
   if (!range) return;
   const row = range.getRow();
+
+  const hdrs = sh.getRange(1, 1, 1, sh.getLastColumn()).getValues()[0];
+  const firstNameCol = hdrs.indexOf('First Name') + 1;
+  const lastNameCol  = hdrs.indexOf('Last Name') + 1;
+  const emailCol     = hdrs.indexOf('Email') + 1;
+  const statusCol    = hdrs.indexOf('Status') + 1;
+  const stageCol     = hdrs.indexOf('Stage') + 1;
+
+  if (
+    firstNameCol < 1 ||
+    lastNameCol < 1 ||
+    emailCol < 1 ||
+    statusCol < 1 ||
+    stageCol < 1
+  ) {
+    throw new Error('Headers required: First Name, Last Name, Email, Status, Stage');
+  }
+
+  const vals  = sh.getRange(row, 1, 1, sh.getLastColumn()).getValues()[0];
+  const first = (vals[firstNameCol - 1] || '').toString();
+  const last  = (vals[lastNameCol - 1]  || '').toString();
+  const email = vals[emailCol - 1];
+
+  if (!email) return;
+  if (!first && !last) return;
+
   sendInitialForRow(email, first, row);
 
   if (stageCol > 0) {
@@ -203,8 +229,8 @@ function startOutreachForSelectedRow() {
   }
 
   if (statusCol > 0) {
-    const cell  = sh.getRange(row, statusCol);
-    const tags  = (cell.getValue() || '')
+    const cell = sh.getRange(row, statusCol);
+    const tags = (cell.getValue() || '')
       .toString()
       .split(',')
       .map(t => t.trim())


### PR DESCRIPTION
## Summary
- read header row inside `startOutreachForSelectedRow`
- extract first name and email from the active row
- call `sendInitialForRow()` after verifying row data
- update `Status` and `Stage` columns once outreach is sent

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684991de2d8083289d3e8e91931b537a