### PR TITLE
Add email thread link in sheet

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,8 @@
  5. Customize the template text and delay constants in `code.gs` as needed.
 6. Each run checks the time since the last message in every thread and sends the next follow‑up when due.
    The **Stage** column records which template was sent and is updated before each email is delivered.
-   The **Email Link** column stores a link to the Gmail thread.
+   The **Email Link** column automatically stores a link to the Gmail thread
+   when the initial outreach email is sent.
 
  
  With the Gmail service enabled and triggers installed, the script manages your outreach and follow‑ups directly from Gmail while updating status information in your spreadsheet.

--- a/code.gs
+++ b/code.gs
@@ -169,10 +169,15 @@ function sendInitialForRow(email, firstName, rowIndex) {
     const ss   = SpreadsheetApp.getActiveSpreadsheet();
     const sh   = ss.getSheetByName(TARGET_SHEET_NAME);
     if (sh) {
-      const hdrs = sh.getRange(1, 1, 1, sh.getLastColumn()).getValues()[0];
-      const col  = hdrs.indexOf('Thread ID') + 1;
-      if (col > 0) {
-        sh.getRange(rowIndex, col).setValue(response.threadId);
+      const hdrs      = sh.getRange(1, 1, 1, sh.getLastColumn()).getValues()[0];
+      const threadCol = hdrs.indexOf('Thread ID') + 1;
+      const linkCol   = hdrs.indexOf('Email Link') + 1;
+      if (threadCol > 0) {
+        sh.getRange(rowIndex, threadCol).setValue(response.threadId);
+      }
+      if (linkCol > 0) {
+        const url = 'https://mail.google.com/mail/u/0/#inbox/' + response.threadId;
+        sh.getRange(rowIndex, linkCol).setValue(url);
       }
     }
   }


### PR DESCRIPTION
## Summary
- capture Gmail thread link when outreach email is sent
- document automatic email link creation

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6849bf167b848328955592bf961f3670